### PR TITLE
Edit boost functionality + boost owner checks [CIVIL-736]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babel/core": "7.2.2",
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-conventional": "^7.5.0",
-    "@joincivil/components": "^1.8.0",
+    "@joincivil/components": "^1.9.0",
     "@joincivil/core": "^4.8.0",
     "@joincivil/ethapi": "^0.4.0",
     "@joincivil/utils": "^1.9.0",

--- a/src/react/boosts/Boost.stories.tsx
+++ b/src/react/boosts/Boost.stories.tsx
@@ -19,6 +19,9 @@ const boost = {
     { item: "Flyers and materials", cost: 100 },
     { item: "Stage equipment", cost: 25 },
   ],
+  channelID: "0xabc123",
+  goalAmount: 325,
+  paymentsTotal: 25,
 };
 
 const typeDefs = `
@@ -40,6 +43,12 @@ const mocks = {
   },
 };
 
+const newsroomData = {
+  name: "Block Club Chicago",
+  url: "https://blockclubchicago.org/",
+  charter: {},
+} as any;
+
 const onClickFunc = () => {
   console.log("clicked!");
 };
@@ -55,17 +64,10 @@ storiesOf("Boosts", module)
     return (
       <BoostCard
         boostOwner={true}
-        channelId={boost.address}
+        newsroomData={newsroomData}
+        boostData={boost}
         open={false}
         boostId={boost.id}
-        title={boost.title}
-        goalAmount={325}
-        paymentsTotal={25}
-        dateEnd={boost.dateEnd}
-        why={boost.why}
-        what={boost.what}
-        about={boost.about}
-        items={boost.items}
         handlePayments={onClickFunc}
       />
     );
@@ -73,18 +75,11 @@ storiesOf("Boosts", module)
   .add("Card Full View", () => {
     return (
       <BoostCard
+        boostData={boost}
+        newsroomData={newsroomData}
         boostOwner={true}
-        channelId={boost.address}
         open={true}
         boostId={boost.id}
-        title={boost.title}
-        goalAmount={325}
-        paymentsTotal={25}
-        dateEnd={boost.dateEnd}
-        why={boost.why}
-        what={boost.what}
-        about={boost.about}
-        items={boost.items}
         handlePayments={onClickFunc}
       />
     );

--- a/src/react/boosts/Boost.tsx
+++ b/src/react/boosts/Boost.tsx
@@ -56,10 +56,18 @@ export class Boost extends React.Component<BoostProps, BoostState> {
       <Query query={boostQuery} variables={{ id }}>
         {({ loading, error, data }) => {
           if (loading) {
-            return <LoadingMessage>Loading Boost</LoadingMessage>;
+            return (
+              <BoostWrapper open={this.props.open}>
+                <LoadingMessage>Loading Boost</LoadingMessage>
+              </BoostWrapper>
+            );
           } else if (error) {
-            console.error("error loading boost data:", error, data);
-            return "Error loading Boost: " + JSON.stringify(error);
+            console.error("error loading boost data. error:", error, "data:", data);
+            return (
+              <BoostWrapper open={this.props.open}>
+                Error loading Boost: {error ? JSON.stringify(error) : "No Boost data found"}
+              </BoostWrapper>
+            );
           }
           const boostData = data.postsGet as BoostData;
 
@@ -76,10 +84,21 @@ export class Boost extends React.Component<BoostProps, BoostState> {
             <Query query={boostNewsroomQuery} variables={{ addr: boostData.channelID }}>
               {({ loading: newsroomQueryLoading, error: newsroomQueryError, data: newsroomQueryData }) => {
                 if (newsroomQueryLoading) {
-                  return <LoadingMessage>Loading Newsroom</LoadingMessage>;
+                  return (
+                    <BoostWrapper open={this.props.open}>
+                      <LoadingMessage>Loading Newsroom</LoadingMessage>
+                    </BoostWrapper>
+                  );
                 } else if (newsroomQueryError || !newsroomQueryData || !newsroomQueryData.listing) {
-                  console.error("error loading newsroom data:", newsroomQueryError, newsroomQueryData);
-                  return "Error loading Boost newsroom data: " + JSON.stringify(newsroomQueryError);
+                  console.error("error loading newsroom data. error:", newsroomQueryError, "data:", newsroomQueryData);
+                  return (
+                    <BoostWrapper open={this.props.open}>
+                      Error loading Boost newsroom data:{" "}
+                      {newsroomQueryError
+                        ? JSON.stringify(newsroomQueryError)
+                        : `No newsroom listing found at ${boostData.channelID}`}
+                    </BoostWrapper>
+                  );
                 }
                 const newsroomData = newsroomQueryData.listing as BoostNewsroomData;
 
@@ -121,19 +140,23 @@ export class Boost extends React.Component<BoostProps, BoostState> {
     const listingUrl = "https://registry.civil.co/listing/" + boostData.channelID;
 
     if (this.state.checkingIfOwner) {
-      return <LoadingMessage>Loading Permissions</LoadingMessage>;
+      return (
+        <BoostWrapper open={this.props.open}>
+          <LoadingMessage>Loading Permissions</LoadingMessage>
+        </BoostWrapper>
+      );
     }
     if (!this.state.boostOwner) {
       if (!this.state.userEthAddress) {
         return (
-          <BoostWrapper open={true}>
+          <BoostWrapper open={this.props.open}>
             Please connect your Ethereum account via a browser wallet such as MetaMask so that we can verify your
             ability to edit this Boost.
           </BoostWrapper>
         );
       }
       return (
-        <BoostWrapper open={true}>
+        <BoostWrapper open={this.props.open}>
           <p>
             Your ETH address <code>{this.state.userEthAddress}</code> doesn't have permissions to edit this newsroom's
             Boost, which is owned by the following address(es):

--- a/src/react/boosts/Boost.tsx
+++ b/src/react/boosts/Boost.tsx
@@ -3,20 +3,28 @@ import { Query } from "react-apollo";
 import { boostQuery, boostNewsroomQuery } from "./queries";
 import { BoostData, BoostNewsroomData } from "./types";
 import { BoostCard } from "./BoostCard";
+import { BoostForm } from "./BoostForm";
 import { BoostPayments } from "./payments/BoostPayments";
-import { EthAddress } from "@joincivil/core";
+import { BoostWrapper } from "./BoostStyledComponents";
+import { Civil, EthAddress } from "@joincivil/core";
+import { detectProvider } from "@joincivil/ethapi";
 import { LoadingMessage } from "@joincivil/components";
 
 export interface BoostProps {
-  boostOwner: boolean;
   boostId: string;
   open: boolean;
+  disableOwnerCheck?: boolean;
+  editMode?: boolean;
 }
 
 export interface BoostState {
   payment: boolean;
-  newsroomName: string;
-  paymentAddr: EthAddress;
+  boostOwner?: boolean;
+  checkingIfOwner?: boolean;
+  newsroomAddress?: EthAddress;
+  userEthAddress?: EthAddress;
+  newsroomOwners?: EthAddress[];
+  civil?: Civil;
 }
 
 export class Boost extends React.Component<BoostProps, BoostState> {
@@ -24,9 +32,21 @@ export class Boost extends React.Component<BoostProps, BoostState> {
     super(props);
     this.state = {
       payment: false,
-      newsroomName: "",
-      paymentAddr: "",
+      checkingIfOwner: props.editMode, // don't need to display loading state for owner checking if not edit mode, because view only changes slightly in that case
     };
+  }
+
+  public async componentDidMount(): Promise<void> {
+    await this.getUserEthAddress();
+  }
+
+  public async componentDidUpdate(prevProps: BoostProps, prevState: BoostState): Promise<void> {
+    if (
+      prevState.userEthAddress !== this.state.userEthAddress ||
+      prevState.newsroomAddress !== this.state.newsroomAddress
+    ) {
+      await this.checkIfBoostOwner();
+    }
   }
 
   public render(): JSX.Element {
@@ -36,12 +56,21 @@ export class Boost extends React.Component<BoostProps, BoostState> {
       <Query query={boostQuery} variables={{ id }}>
         {({ loading, error, data }) => {
           if (loading) {
-            return <LoadingMessage />;
+            return <LoadingMessage>Loading Boost</LoadingMessage>;
           } else if (error) {
             console.error("error loading boost data:", error, data);
             return "Error loading Boost: " + JSON.stringify(error);
           }
           const boostData = data.postsGet as BoostData;
+
+          // @HACK/tobek: Bad form to call setState from render (putting in setImmediate to remove React warning) but the conditional prevents an infinite loop, and the only alternative is to use `withApollo` and get apollo client as prop and call this query on `componentDidMount` or something, which is an annoying refactor right now.
+          if (this.state.newsroomAddress !== boostData.channelID) {
+            setImmediate(() => {
+              this.setState({
+                newsroomAddress: boostData.channelID,
+              });
+            });
+          }
 
           return (
             <Query query={boostNewsroomQuery} variables={{ addr: boostData.channelID }}>
@@ -53,6 +82,10 @@ export class Boost extends React.Component<BoostProps, BoostState> {
                   return "Error loading Boost newsroom data: " + JSON.stringify(newsroomQueryError);
                 }
                 const newsroomData = newsroomQueryData.listing as BoostNewsroomData;
+
+                if (this.props.editMode) {
+                  return this.renderEditMode(boostData, newsroomData);
+                }
 
                 if (this.state.payment) {
                   return (
@@ -84,7 +117,103 @@ export class Boost extends React.Component<BoostProps, BoostState> {
     );
   }
 
+  private renderEditMode(boostData: BoostData, newsroomData: BoostNewsroomData): JSX.Element {
+    const listingUrl = "https://registry.civil.co/listing/" + boostData.channelID;
+
+    if (this.state.checkingIfOwner) {
+      return <LoadingMessage>Loading Permissions</LoadingMessage>;
+    }
+    if (!this.state.boostOwner) {
+      if (!this.state.userEthAddress) {
+        return (
+          <BoostWrapper open={true}>
+            Please connect your Ethereum account via a browser wallet such as MetaMask so that we can verify your
+            ability to edit this Boost.
+          </BoostWrapper>
+        );
+      }
+      return (
+        <BoostWrapper open={true}>
+          <p>
+            Your ETH address <code>{this.state.userEthAddress}</code> doesn't have permissions to edit this newsroom's
+            Boost, which is owned by the following address(es):
+          </p>
+          {this.state.newsroomOwners && (
+            <ul>
+              {this.state.newsroomOwners.map(owner => (
+                <li key={owner}>
+                  <code>{owner}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+          <p>
+            If you own one of these wallets, please switch to it. Otherwise, please request that one of these officers
+            add you to the newsroom contract.
+          </p>
+          <p>
+            <a href={listingUrl}>View newsroom information.</a>
+          </p>
+        </BoostWrapper>
+      );
+    }
+
+    return (
+      <BoostForm
+        editMode={true}
+        initialBoostData={boostData}
+        newsroomData={newsroomData}
+        newsroomAddress={boostData.channelID}
+        newsroomListingUrl={listingUrl}
+      />
+    );
+  }
+
   private startPayment = () => {
     this.setState({ payment: true });
   };
+
+  private async getUserEthAddress(): Promise<void> {
+    if (this.props.disableOwnerCheck) {
+      return;
+    }
+
+    let user;
+    const provider = detectProvider();
+    if (provider) {
+      const civil = new Civil({ web3Provider: provider });
+      user = await civil.accountStream.first().toPromise();
+
+      if (user) {
+        this.setState({
+          userEthAddress: user,
+          civil,
+        });
+      }
+    }
+
+    if (!user) {
+      this.setState({
+        checkingIfOwner: false,
+        boostOwner: false,
+      });
+    }
+  }
+
+  private async checkIfBoostOwner(): Promise<void> {
+    if (this.props.disableOwnerCheck) {
+      return;
+    }
+
+    if (this.state.userEthAddress && this.state.newsroomAddress && this.state.civil) {
+      const newsroom = await this.state.civil.newsroomAtUntrusted(this.state.newsroomAddress);
+      const newsroomOwners = (await newsroom.getNewsroomData()).owners;
+
+      this.setState({
+        checkingIfOwner: false,
+        boostOwner: newsroomOwners && newsroomOwners.indexOf(this.state.userEthAddress) !== -1,
+        newsroomOwners,
+      });
+    }
+  }
 }

--- a/src/react/boosts/BoostCard.tsx
+++ b/src/react/boosts/BoostCard.tsx
@@ -62,6 +62,13 @@ export class BoostCard extends React.Component<BoostCardProps> {
               <BoostNewsroom>{this.props.newsroomData.name}</BoostNewsroom>
               {this.props.open && (
                 <>
+                  {this.props.boostOwner && (
+                    <a href={`/boosts/${this.props.boostId}/edit?feature-flag=boosts-mvp`}>
+                      <b>
+                        Edit Boost <MobileStyle>&raquo;</MobileStyle>
+                      </b>
+                    </a>
+                  )}
                   <a href={this.props.newsroomData.url} target="_blank">
                     Visit Newsroom <MobileStyle>&raquo;</MobileStyle>
                   </a>

--- a/src/react/boosts/BoostFeed.tsx
+++ b/src/react/boosts/BoostFeed.tsx
@@ -19,7 +19,8 @@ export const BoostFeed: React.FunctionComponent = () => {
           }
 
           return data.postsSearch.posts.map((boost: any, i: number) => (
-            <Boost key={i} boostId={boost.id} open={false} boostOwner={false} />
+            // `disableOwnerCheck` true because it would be slow to pull up newsroom from web3 for every single boost
+            <Boost key={i} boostId={boost.id} open={false} disableOwnerCheck={true} />
           ));
         }}
       </Query>

--- a/src/react/boosts/BoostForm.tsx
+++ b/src/react/boosts/BoostForm.tsx
@@ -239,8 +239,8 @@ export class BoostForm extends React.Component<BoostFormProps, BoostFormState> {
         <>
           <Title>Edit Boost</Title>
           <p>
-            Note that after a boost has been launched, only copy can be changed. Goal amounts and end date cannot be
-            edited.
+            Note that after a boost has been launched, only text copy can be changed. Goal amounts and end date cannot
+            be edited.
           </p>
         </>
       );

--- a/src/react/boosts/BoostImg.tsx
+++ b/src/react/boosts/BoostImg.tsx
@@ -16,7 +16,7 @@ const ipfsAsync = {
 };
 
 export interface BoostImgProps {
-  charterUri: string;
+  charterUri?: string;
 }
 
 export interface BoostImgState {
@@ -32,6 +32,9 @@ export class BoostImg extends React.Component<BoostImgProps, BoostImgState> {
     };
   }
   public async componentDidMount(): Promise<void> {
+    if (!this.props.charterUri) {
+      return;
+    }
     const uri = this.props.charterUri.replace("ipfs://", "/ipfs/");
     const content = await ipfsAsync.get(uri);
     const ipfsFile = content.reduce((acc, file) => acc + file.content.toString("utf8"), "");

--- a/src/react/boosts/BoostProgress.tsx
+++ b/src/react/boosts/BoostProgress.tsx
@@ -90,7 +90,7 @@ export const BoostProgress: React.FunctionComponent<BoostProgressProps> = props 
   return (
     <BoostProgressWrapper>
       <BoostProgressFlex>
-        <TextPrimary>{"$" + (props.paymentsTotal).toFixed(2)} raised</TextPrimary>
+        <TextPrimary>{"$" + props.paymentsTotal.toFixed(2)} raised</TextPrimary>
         <AlignRight>
           <TextPrimary>
             <b>${props.goalAmount}</b> goal

--- a/src/react/boosts/BoostStyledComponents.tsx
+++ b/src/react/boosts/BoostStyledComponents.tsx
@@ -449,7 +449,7 @@ export const BoostModalCloseBtn: StyledComponentClass<ButtonProps, "button"> = s
 
 export const BoostSmallPrint = styled.div`
   font-size: 12px;
-  margin: ${(props: BoostStyleProps) => (props.margin || "0")};
+  margin: ${(props: BoostStyleProps) => props.margin || "0"};
 `;
 
 export const BoostEthConfirm = styled.span`
@@ -468,7 +468,7 @@ export const BoostNotice = styled.div`
   }
 `;
 
-export const BoostCompeletedWrapper = styled.div `
+export const BoostCompeletedWrapper = styled.div`
   border: 1px solid ${colors.accent.CIVIL_GRAY_2};
   font-family: ${fonts.SANS_SERIF};
   font-size: 14px;
@@ -481,7 +481,8 @@ export const BoostCompeletedWrapper = styled.div `
     margin: 15px 10px;
   }
 
-  h3, p {
+  h3,
+  p {
     font-size: 14px;
     line-height: 20px;
     margin: 0 0 10px;

--- a/src/react/boosts/loader.tsx
+++ b/src/react/boosts/loader.tsx
@@ -12,7 +12,7 @@ function init(): void {
   ReactDOM.render(
     // `apolloClient as any` because of bug with types e.g. https://github.com/awslabs/aws-mobile-appsync-sdk-js/issues/166
     <ApolloProvider client={apolloClient as any}>
-      <Boost boostOwner={true} boostId={"1bdf971f-54e9-472d-a975-e175c5fccaa1"} open={true} />
+      <Boost boostId={"1bdf971f-54e9-472d-a975-e175c5fccaa1"} open={true} />
     </ApolloProvider>,
     document.getElementById("civil-boost"),
   );

--- a/src/react/boosts/payments/BoostPayForm.tsx
+++ b/src/react/boosts/payments/BoostPayForm.tsx
@@ -144,9 +144,9 @@ export class BoostPayForm extends React.Component<BoostPayFormProps, BoostPayFor
                 Support this Boost
               </TransactionButton>
               <SubmitWarning>
-                By sending a Boost, you agree to Civil’s <a href="#TODO">Terms of Use and Privacy Policy</a>. Civil does not charge any fees
-                for this transaction. There are small fees charged by the Ethereum network. Depending on your selection,
-                your email and comment may be visible to the newsroom.
+                By sending a Boost, you agree to Civil’s <a href="#TODO">Terms of Use and Privacy Policy</a>. Civil does
+                not charge any fees for this transaction. There are small fees charged by the Ethereum network.
+                Depending on your selection, your email and comment may be visible to the newsroom.
               </SubmitWarning>
             </div>
           </BoostFlexStart>

--- a/src/react/boosts/queries.ts
+++ b/src/react/boosts/queries.ts
@@ -68,6 +68,26 @@ export const boostMutation = gql`
   }
 `;
 
+// @TODO/toby Change this over when edit mutation is live
+export const editBoostMutation = gql`
+  mutation($input: PostCreateBoostInput!) {
+    postsCreateBoost(input: $input) {
+      id
+      channelID
+      goalAmount
+      title
+      why
+      what
+      about
+      dateEnd
+      items {
+        item
+        cost
+      }
+    }
+  }
+`;
+
 export const boostPayEthMutation = gql`
   mutation($postID: String!, $input: PaymentsCreateEtherPaymentInput!) {
     paymentsCreateEtherPayment(postID: $postID, input: $input) {

--- a/src/react/boosts/types.ts
+++ b/src/react/boosts/types.ts
@@ -1,13 +1,25 @@
 export interface BoostData {
   title: string;
   goalAmount: number;
-  dateEnd: Date;
+  paymentsTotal: number;
+  dateEnd: string;
   why: string;
   what: string;
   about: string;
+  channelID: string;
   items: BoostCostItem[];
 }
+
 export interface BoostCostItem {
   item: string;
   cost: number;
+}
+
+export interface BoostNewsroomData {
+  name: string;
+  url: string;
+  owner: string;
+  charter?: {
+    uri: string;
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,13 +1203,19 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@joincivil/artifacts/-/artifacts-1.1.0.tgz#95838ffd69ea3ce0154ffde477ac93cddd63e106"
 
-"@joincivil/components@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@joincivil/components/-/components-1.8.0.tgz#8d927c1b308d4e93d17e7c6115a7c48b3c8dd072"
+"@joincivil/artifacts@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@joincivil/artifacts/-/artifacts-1.1.1.tgz#b2e366ed314e00476c9873e2dcb796d12e9eb212"
+  integrity sha512-1qAo/iCgTZmhyhHpJD25Va9LTzF2CMHZAe0RUl4r0Z1C9SRlxgFMECK4pi70o62hnj2/uXNCreZOACJOmYntpw==
+
+"@joincivil/components@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@joincivil/components/-/components-1.9.0.tgz#fbfd842edf9cfcbdad4711205de66f2584b7e83b"
+  integrity sha512-b6kAN4zKJEnIO/AnahQjDqRjRrYJMR1Q8MQBUWXJz9yvrvz4U2dEV/H1Attb6FqR8UEQL/+N6UErgSGPWMk5iA==
   dependencies:
-    "@joincivil/core" "^4.8.0"
-    "@joincivil/ethapi" "^0.4.0"
-    "@joincivil/utils" "^1.9.0"
+    "@joincivil/core" "^4.8.1"
+    "@joincivil/ethapi" "^0.4.1"
+    "@joincivil/utils" "^1.9.1"
     apollo-storybook-react "^0.1.8"
     classnames "^2.2.5"
     graphql-tag "^2.10.0"
@@ -1241,12 +1247,43 @@
     rxjs "^5.5.6"
     web3 "^0.20.3"
 
+"@joincivil/core@^4.8.1":
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/@joincivil/core/-/core-4.8.1.tgz#128c6828fe06a36f87e3384e67233f3a4312dfc9"
+  integrity sha512-MWyt1x9vnebD/aZNvjpZddb0UyLgNrjj047pTdhSavrQ74WwJMfXcIrpytzfTxYyyR9u3xf+B+mGJTtxX7peyg==
+  dependencies:
+    "@joincivil/artifacts" "^1.1.1"
+    "@joincivil/ethapi" "^0.4.1"
+    "@joincivil/utils" "^1.9.1"
+    bignumber.js "~5.0.0"
+    debug "^4.1.0"
+    ethereumjs-util "^5.2.0"
+    ethers "^4.0.27"
+    events "^3.0.0"
+    ipfs-http-client "^29.1.1"
+    rxjs "^5.5.6"
+    web3 "^0.20.3"
+
 "@joincivil/ethapi@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@joincivil/ethapi/-/ethapi-0.4.0.tgz#5a3a121ae8997abf47ca8054868b560677396b9b"
   dependencies:
     "@joincivil/typescript-types" "^1.4.0"
     "@joincivil/utils" "^1.9.0"
+    bignumber.js "^5.0.0"
+    debug "^4.1.0"
+    ethereumjs-util "^5.2.0"
+    lodash "^4.17.10"
+    rxjs "^5.5.6"
+    web3 "^0.20.3"
+
+"@joincivil/ethapi@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@joincivil/ethapi/-/ethapi-0.4.1.tgz#6d49053830e03b92acb2c5001aabde90b4645cd5"
+  integrity sha512-5ikZoK10RZ6uFyGZ1n3kZz8qdzDlT63sRvBnEOCJFwmut77tqBMs2XgYLoBDKsYDb114yZmfCTBg1j+ETnrxYw==
+  dependencies:
+    "@joincivil/typescript-types" "^1.4.1"
+    "@joincivil/utils" "^1.9.1"
     bignumber.js "^5.0.0"
     debug "^4.1.0"
     ethereumjs-util "^5.2.0"
@@ -1264,9 +1301,38 @@
   dependencies:
     bignumber.js "^5.0.0"
 
+"@joincivil/typescript-types@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@joincivil/typescript-types/-/typescript-types-1.4.1.tgz#6a6d11e117f971c9e4c6a66f7bd5c3b12b7ccf6b"
+  integrity sha512-PvEyecwgqftEhvTm8oZ0Zm1Bxx9PQ6aR2cRtbEvk5XW4QUQATRyrKZ1W/jWu7AN1LBl11QbjWMLfXliLZPWakw==
+  dependencies:
+    bignumber.js "^5.0.0"
+
 "@joincivil/utils@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@joincivil/utils/-/utils-1.9.0.tgz#8b0ee3fbbe488c018da6d9bdf5e69985fca29e83"
+  dependencies:
+    apollo-boost "^0.1.16"
+    apollo-cache-inmemory "^1.3.12"
+    apollo-client "^2.4.8"
+    apollo-link "^1.2.6"
+    apollo-link-context "^1.0.12"
+    apollo-link-error "^1.1.5"
+    apollo-link-http "^1.5.9"
+    bignumber.js "~5.0.0"
+    detect-browser "^4.1.0"
+    eth-sig-util "^1.4.2"
+    ethereumjs-abi "^0.6.5"
+    ethereumjs-util "^5.2.0"
+    graphql "^14.0.2"
+    graphql-tag "^2.9.2"
+    rxjs "^5.5.6"
+    sanitize-html "^1.20.0"
+
+"@joincivil/utils@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@joincivil/utils/-/utils-1.9.1.tgz#8ab6da30b61fe53c56da3d55a852b7c47f41e7b0"
+  integrity sha512-ycn9RWOPZpmqC7X48YuEitWcD2/zQzgYJ1QKfS0IZ9SSGtbLI/55TKkQeIGAWwLJoXOgEQhWZaDG7j01FXecrw==
   dependencies:
     apollo-boost "^0.1.16"
     apollo-cache-inmemory "^1.3.12"


### PR DESCRIPTION
Also some notable refactors:

- Newsroom query lifted out of `BoostCard` and into `Boost` so that it can be reused by boost owner checks and edit boost stuff
- Boost and newsroom data refactored into reusable types

I'm expecting this build to fail because it relies on changes in monorepo, and I'm expecting monorepo build to fail because it relies on changes here. Not sure how to resolve. We'll see if it magically works. If not I guess I can go through and comment out the changes in this PR that rely on monorepo updates and do it all over 3 PRs instead of 2?

Update: I split out changes in monorepo into one standalone PR https://github.com/joincivil/Civil/pull/1287 that doesn't depend on civil-sdk changes that, once merged and npm published, will make this PR build.