### PR TITLE
refactor: create HOC for checking create/edit boost permissions

### DIFF
--- a/src/react/boosts/BoostForm.tsx
+++ b/src/react/boosts/BoostForm.tsx
@@ -31,6 +31,7 @@ import {
 import { BoostImg } from "./BoostImg";
 import { urlConstants } from "../urlConstants";
 import * as boostCardImage from "../../images/boost-card.png";
+import { withBoostPermissions, BoostPermissionsInjectedProps } from "./BoostPermissionsHOC";
 
 const PageWrapper = styled.div`
   color: ${colors.primary.CIVIL_GRAY_0};
@@ -162,7 +163,7 @@ const LaunchButton = styled(Button)`
   width: 190px;
 `;
 
-export interface BoostFormProps {
+export interface BoostFormInnerProps {
   newsroomData: BoostNewsroomData;
   newsroomAddress: string;
   newsroomListingUrl: string;
@@ -172,6 +173,8 @@ export interface BoostFormProps {
   editMode?: boolean;
   boostId?: string;
 }
+export type BoostFormProps = BoostFormInnerProps & BoostPermissionsInjectedProps;
+
 export interface BoostFormState {
   boost: Partial<BoostData>;
   changesMade?: boolean;
@@ -181,7 +184,7 @@ export interface BoostFormState {
   error?: string;
 }
 
-export class BoostForm extends React.Component<BoostFormProps, BoostFormState> {
+class BoostFormComponent extends React.Component<BoostFormProps, BoostFormState> {
   constructor(props: BoostFormProps) {
     super(props);
     this.state = {
@@ -195,6 +198,9 @@ export class BoostForm extends React.Component<BoostFormProps, BoostFormState> {
   }
 
   public async componentDidMount(): Promise<void> {
+    // Set up boost permissions checks HOC:
+    this.props.setNewsroomAddress(this.props.newsroomAddress);
+
     // If changes have been made, and boost create/update is not complete, show "are you sure you want to leave?" prompt. See also <Prompt> component with same check for react router below.
     window.addEventListener("beforeunload", this.beforeUnloadHandler);
   }
@@ -640,3 +646,5 @@ export class BoostForm extends React.Component<BoostFormProps, BoostFormState> {
     }
   };
 }
+
+export const BoostForm = withBoostPermissions(BoostFormComponent, true);

--- a/src/react/boosts/BoostPermissionsHOC.tsx
+++ b/src/react/boosts/BoostPermissionsHOC.tsx
@@ -1,0 +1,212 @@
+import * as React from "react";
+import { EthAddress, NewsroomInstance } from "@joincivil/core";
+import { LoadingMessage, CivilContext, ICivilContext } from "@joincivil/components";
+import { BoostWrapper } from "./BoostStyledComponents";
+
+export interface BoostPermissionsOuterProps {
+  disableOwnerCheck?: boolean;
+  editMode?: boolean;
+}
+
+export interface BoostPermissionsInjectedProps {
+  boostOwner?: boolean;
+  walletConnected?: boolean;
+  newsroom?: NewsroomInstance;
+  setNewsroomAddress(address: EthAddress): void;
+}
+
+export interface BoostPermissionsState {
+  waitingForEthEnable?: boolean;
+  boostOwner?: boolean;
+  walletConnected?: boolean;
+  checkingIfOwner?: boolean;
+  userEthAddress?: EthAddress;
+  newsroomOwners?: EthAddress[];
+  newsroom?: NewsroomInstance;
+  newsroomAddress?: EthAddress;
+}
+
+/** Usage: Wrap component with this HOC and make sure to call the injected prop `setNewsroomAddress` with the newsroom address once that is loaded. */
+export const withBoostPermissions = <TOriginalProps extends {}>(
+  WrappedComponent: React.ComponentType<TOriginalProps & BoostPermissionsInjectedProps>,
+  requirePermissions?: boolean,
+) => {
+  return class ComponentWithBoostPermissions extends React.Component<
+    BoostPermissionsOuterProps & TOriginalProps,
+    BoostPermissionsState
+  > {
+    public static contextType: React.Context<ICivilContext> = CivilContext;
+    public context!: React.ContextType<typeof CivilContext>;
+
+    constructor(props: TOriginalProps & BoostPermissionsInjectedProps) {
+      super(props);
+      this.state = {
+        checkingIfOwner: true,
+      };
+    }
+
+    public async componentDidMount(): Promise<void> {
+      // @TODO/loginV2 migrate away from window.ethereum
+      if ((window as any).ethereum) {
+        this.setState({
+          waitingForEthEnable: true,
+        });
+        await (window as any).ethereum.enable();
+        this.setState({
+          waitingForEthEnable: false,
+        });
+        await this.getUserEthAddress();
+      } else {
+        this.setState({
+          checkingIfOwner: false,
+        });
+      }
+    }
+
+    public async componentDidUpdate(
+      prevProps: BoostPermissionsOuterProps,
+      prevState: BoostPermissionsState,
+    ): Promise<void> {
+      if (
+        prevState.userEthAddress !== this.state.userEthAddress ||
+        prevState.newsroomAddress !== this.state.newsroomAddress
+      ) {
+        await this.checkIfBoostOwner();
+      }
+    }
+
+    public render(): JSX.Element {
+      // If editMode/requirePermissions then entire view depends on if user is owner, so block everything and show loading or permissions messages:
+      if ((this.props.editMode || requirePermissions) && this.state.newsroomAddress) {
+        if (this.state.waitingForEthEnable) {
+          return this.renderNotConnected();
+        }
+
+        if (this.state.checkingIfOwner) {
+          return this.renderLoading();
+        }
+
+        if (!this.state.boostOwner) {
+          if (!this.state.userEthAddress) {
+            return this.renderNotConnected();
+          }
+          return this.renderNotOnContract();
+        }
+      }
+
+      return (
+        <WrappedComponent
+          boostOwner={this.state.boostOwner}
+          walletConnected={this.state.walletConnected}
+          newsroom={this.state.newsroom}
+          setNewsroomAddress={this.setNewsroomAddress}
+          {...this.props}
+        />
+      );
+    }
+
+    public renderLoading(): JSX.Element {
+      return (
+        <BoostWrapper open={true}>
+          <LoadingMessage>Loading Permissions</LoadingMessage>
+        </BoostWrapper>
+      );
+    }
+
+    public renderNotConnected(): JSX.Element {
+      return (
+        <BoostWrapper open={true}>
+          <p>
+            Please connect your Ethereum account via a browser wallet such as MetaMask so that we can verify your
+            ability to create and edit Boosts for this newsroom.
+          </p>
+        </BoostWrapper>
+      );
+    }
+
+    public renderNotOnContract(): JSX.Element {
+      return (
+        <BoostWrapper open={true}>
+          <p>
+            Your ETH address <code>{this.state.userEthAddress}</code> doesn't have permissions to create and edit Boosts
+            for this newsroom, which is owned by the following address(es):
+          </p>
+          {this.state.newsroomOwners && (
+            <ul>
+              {this.state.newsroomOwners.map(owner => (
+                <li key={owner}>
+                  <code>{owner}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+          <p>
+            If you own one of these wallets, please switch to it. Otherwise, please request that one of these officers
+            add you to the newsroom contract.
+          </p>
+          <p>
+            <a href={"https://registry.civil.co/listing/" + this.state.newsroomAddress}>View newsroom information.</a>
+          </p>
+        </BoostWrapper>
+      );
+    }
+
+    public async getUserEthAddress(): Promise<void> {
+      if (this.props.disableOwnerCheck) {
+        return;
+      }
+
+      let user;
+      if (this.context.civil) {
+        user = await this.context.civil.accountStream.first().toPromise();
+
+        if (user) {
+          this.setState({
+            walletConnected: true,
+            userEthAddress: user,
+          });
+        } else {
+          this.setState({
+            walletConnected: true,
+          });
+        }
+      }
+
+      if (!user) {
+        this.setState({
+          checkingIfOwner: false,
+          boostOwner: false,
+        });
+      }
+    }
+
+    public async checkIfBoostOwner(): Promise<void> {
+      if (this.props.disableOwnerCheck) {
+        return;
+      }
+
+      if (this.state.userEthAddress && this.state.newsroomAddress && this.context.civil) {
+        const newsroom = await this.context.civil.newsroomAtUntrusted(this.state.newsroomAddress);
+        const newsroomOwners = (await newsroom.getNewsroomData()).owners;
+
+        this.setState({
+          checkingIfOwner: false,
+          boostOwner: newsroomOwners && newsroomOwners.indexOf(this.state.userEthAddress) !== -1,
+          newsroomOwners,
+          newsroom,
+        });
+      }
+    }
+
+    public setNewsroomAddress = (newsroomAddress: EthAddress) => {
+      // @HACK/tobek: This gets called from `render()` function of wrapped component because we pick it up from apollo `<Query>` component. Bad form to call setState from render (putting in setImmediate to remove React warning) but the conditional prevents an infinite loop, and the only alternative is to use `withApollo` and get apollo client as prop and call this query on `componentDidMount` in wrapped component or something, which is an annoying refactor right now.
+      if (this.state.newsroomAddress !== newsroomAddress) {
+        setImmediate(() => {
+          this.setState({
+            newsroomAddress,
+          });
+        });
+      }
+    };
+  };
+};


### PR DESCRIPTION
Fixes some edge cases found on launch boost page while looking into CIVIL-892 and CIVIL-894, and improves and standardizes messaging.

This takes a ton of logic out of `Boost` component for checking if user is boost owner and whether they can edit boost, and puts that logic into `withBoostPermissions` HOC, so that `BoostForm` can use it to check newsroom permissions for creating boosts and for showing error/not allowed messages.