### PR TITLE
feat: boost proceeds WIP [CIVIL-1017]

### DIFF
--- a/src/react/NewsroomWithdraw.tsx
+++ b/src/react/NewsroomWithdraw.tsx
@@ -8,12 +8,12 @@ import {
   CivilContext,
   ICivilContext,
   colors,
-  fonts,
   mediaQueries,
   Button,
   TransactionButton,
 } from "@joincivil/components";
 import { BoostButton } from "./boosts/BoostStyledComponents";
+import { BoostProceeds } from "./boosts/BoostProceeds";
 import { urlConstants } from "./urlConstants";
 
 const ethPriceQuery = gql`
@@ -23,16 +23,10 @@ const ethPriceQuery = gql`
 `;
 
 const Wrapper = styled.div`
-  border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
-  border-top: 1px solid ${colors.accent.CIVIL_GRAY_4};
-  display: flex;
-  justify-content: space-between;
-  margin: 36px 0;
-  padding: 32px 0 16px;
+  padding: 0 0 16px;
 
   ${mediaQueries.MOBILE} {
-    display: block;
-    padding: 16px 0 8px;
+    padding: 0 0 8px;
   }
 
   p {
@@ -42,13 +36,13 @@ const Wrapper = styled.div`
     margin: 0 0 16px;
   }
 `;
-const Heading = styled.div`
-  color: ${colors.accent.CIVIL_GRAY_0};
-  font-family: ${fonts.SANS_SERIF};
-  font-size: 17px;
-  font-weight: bold;
-  line-height: 23px;
-  margin-bottom: 18px;
+const WithdrawWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  ${mediaQueries.MOBILE} {
+    display: block;
+  }
 `;
 const Copy = styled.div`
   max-width: 500px;
@@ -73,11 +67,11 @@ const BalanceAndButton = styled.div`
   }
 `;
 
-// Component requires either instance or newsroom address:
 export interface NewsroomWithdrawProps {
+  newsroomAddress: EthAddress;
+  /** Pass newsroom instance if handy to avoid unecessary instantiation. */
   newsroom?: NewsroomInstance;
-  newsroomAddress?: EthAddress;
-  isStripeConnected: boolean;
+  isStripeConnected?: boolean;
 }
 
 export interface NewsroomWithdrawState {
@@ -92,22 +86,23 @@ export class NewsroomWithdraw extends React.Component<NewsroomWithdrawProps, New
 
   public constructor(props: NewsroomWithdrawProps) {
     super(props);
-    if (!props.newsroom && !props.newsroomAddress) {
-      throw Error("NewsroomWithdraw: Must supply either newsroom instance or newsroom address");
-    }
     this.state = {
       newsroom: props.newsroom,
     };
   }
 
   public async componentDidMount(): Promise<void> {
+    if (!this.context.civil) {
+      // Shouldn't happen but let's fail explicity if it does.
+      throw Error("No civil instance in context");
+    }
     const userAccount = await this.context.civil!.accountStream.first().toPromise();
     let newsroom = this.props.newsroom;
     if (!newsroom) {
-      newsroom = await this.context.civil!.newsroomAtUntrusted(this.props.newsroomAddress!);
+      newsroom = await this.context.civil!.newsroomAtUntrusted(this.props.newsroomAddress);
     }
 
-    const multisigAddress = await newsroom.getMultisigAddress();
+    const multisigAddress = await newsroom!.getMultisigAddress();
     if (!multisigAddress) {
       // This can only happen if user created contract manually.
       alert(
@@ -127,43 +122,47 @@ export class NewsroomWithdraw extends React.Component<NewsroomWithdrawProps, New
   public render(): JSX.Element {
     return (
       <Wrapper>
-        <Copy>
-          <Heading>Withdraw funds</Heading>
-          <p>
-            Transfer or withdraw funds from your Newsroom Wallet to collect proceeds from Boosts. You’ll be able to
-            exchange ETH for fiat currency. Reminder: only Newsroom Officers can access the Newsroom Wallet.
-          </p>
-          {this.props.isStripeConnected && (
+        <BoostProceeds newsroomAddress={this.props.newsroomAddress} />
+        <WithdrawWrapper>
+          <Copy>
+            <Heading>Withdraw funds</Heading>
             <p>
-              You may have additional funds in your{" "}
-              <a href="https://dashboard.stripe.com" target="_blank">
-                Stripe account
-              </a>
-              .
+              Transfer or withdraw funds from your Newsroom Wallet to collect proceeds from Boosts. You’ll be able to
+              exchange ETH for fiat currency. Reminder: only Newsroom Officers can access the Newsroom Wallet.
             </p>
-          )}
-          <p>
-            <a target="_blank" href={urlConstants.FAQ_BOOST_WITHDRAWL}>
-              Learn&nbsp;More&nbsp;&gt;
-            </a>
-          </p>
-        </Copy>
-        <BalanceAndButton>
-          <p>
-            Newsroom balance:{" "}
-            <Query query={ethPriceQuery}>
-              {({ loading, error, data }) => {
-                if (loading || typeof this.state.multisigBalance === "undefined") {
-                  return <LoadingIndicator />;
-                }
-                return <b>${(data.storefrontEthPrice * this.state.multisigBalance).toFixed(2)}</b>;
-              }}
-            </Query>
-            <br />
-            {typeof this.state.multisigBalance !== "undefined" && <>({this.state.multisigBalance.toFixed(4)} ETH)</>}
-          </p>
-          {this.renderButton()}
-        </BalanceAndButton>
+            {(this.props.isStripeConnected === true || typeof this.props.isStripeConnected === "undefined") && (
+              <p>
+                {this.props.isStripeConnected === true ? "Y" : "If you have connected Stripe to your newsroom, y"}ou may
+                have additional funds in your{" "}
+                <a href="https://dashboard.stripe.com" target="_blank">
+                  Stripe account
+                </a>
+                .
+              </p>
+            )}
+            <p>
+              <a target="_blank" href={urlConstants.FAQ_BOOST_WITHDRAWL}>
+                Learn&nbsp;More&nbsp;&gt;
+              </a>
+            </p>
+          </Copy>
+          <BalanceAndButton>
+            <p>
+              Newsroom balance:{" "}
+              <Query query={ethPriceQuery}>
+                {({ loading, error, data }) => {
+                  if (loading || typeof this.state.multisigBalance === "undefined") {
+                    return <LoadingIndicator />;
+                  }
+                  return <b>${(data.storefrontEthPrice * this.state.multisigBalance).toFixed(2)}</b>;
+                }}
+              </Query>
+              <br />
+              {typeof this.state.multisigBalance !== "undefined" && <>({this.state.multisigBalance.toFixed(4)} ETH)</>}
+            </p>
+            {this.renderButton()}
+          </BalanceAndButton>
+        </WithdrawWrapper>
       </Wrapper>
     );
   }

--- a/src/react/boosts/Boost.tsx
+++ b/src/react/boosts/Boost.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import styled from "styled-components";
 import { Query } from "react-apollo";
 import { boostQuery, boostNewsroomQuery } from "./queries";
 import { BoostData, BoostNewsroomData } from "./types";
@@ -8,7 +9,18 @@ import { BoostPayments } from "./payments/BoostPayments";
 import { BoostWrapper } from "./BoostStyledComponents";
 import { NewsroomWithdraw } from "../NewsroomWithdraw";
 import { withBoostPermissions, BoostPermissionsInjectedProps } from "./BoostPermissionsHOC";
-import { LoadingMessage, CivilContext, ICivilContext } from "@joincivil/components";
+import { LoadingMessage, CivilContext, ICivilContext, colors, mediaQueries } from "@joincivil/components";
+
+const WithdrawWrapper = styled.div`
+  border-bottom: 1px solid ${colors.accent.CIVIL_GRAY_4};
+  border-top: 1px solid ${colors.accent.CIVIL_GRAY_4};
+  padding: 0 0 16px;
+  margin: 36px 0;
+
+  ${mediaQueries.MOBILE} {
+    margin: 18px 0;
+  }
+`;
 
 export interface BoostInternalProps {
   history?: any;
@@ -123,10 +135,13 @@ class BoostComponent extends React.Component<BoostProps, BoostStates> {
                   <>
                     {/*@TODO/tobek Move to Newsroom Boosts page when we have that.*/}
                     {this.props.open && this.props.newsroom && this.props.boostOwner && (
-                      <NewsroomWithdraw
-                        newsroom={this.props.newsroom}
-                        isStripeConnected={boostData.channel.isStripeConnected}
-                      />
+                      <WithdrawWrapper>
+                        <NewsroomWithdraw
+                          newsroomAddress={boostData.channel.newsroom.contractAddress}
+                          newsroom={this.props.newsroom}
+                          isStripeConnected={boostData.channel.isStripeConnected}
+                        />
+                      </WithdrawWrapper>
                     )}
                     <BoostCard
                       boostData={boostData}

--- a/src/react/boosts/BoostProceeds.tsx
+++ b/src/react/boosts/BoostProceeds.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import styled from "styled-components";
+import { Query } from "react-apollo";
+import {
+  LoadingIndicator,
+  colors,
+  fonts,
+  mediaQueries,
+  withNewsroomChannel,
+  NewsroomChannelInjectedProps,
+} from "@joincivil/components";
+import { boostProceedsQuery } from "./queries";
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 32px 0;
+  font-size: 14px;
+
+  ${mediaQueries.MOBILE} {
+    display: block;
+  }
+`;
+const Proceed = styled.div`
+  padding: 20px;
+  flex: 1;
+`;
+const TotalProceeds = styled(Proceed)`
+  font-family: ${fonts.SANS_SERIF};
+  border: 1px solid ${colors.accent.CIVIL_GRAY_4};
+`;
+
+const Amount = styled.span`
+  color: ${colors.primary.BLACK};
+  font-size: 16px;
+`;
+const TotalAmount = styled(Amount)`
+  font-size: 20px;
+`;
+const CurrencyLabel = styled.span`
+  color: ${colors.primary.CIVIL_GRAY_0};
+  font-size: 12px;
+  font-weight: bold;
+`;
+
+export interface BoostProceedsProps {
+  newsroomAddress: string;
+}
+
+class BoostProceedsComponent extends React.Component<BoostProceedsProps & NewsroomChannelInjectedProps> {
+  public constructor(props: BoostProceedsProps & NewsroomChannelInjectedProps) {
+    super(props);
+  }
+  public render(): JSX.Element {
+    return (
+      <Query query={boostProceedsQuery} variables={{ channelID: this.props.channelData.id }}>
+        {({ loading, error, data }) => {
+          if (loading) {
+            return <LoadingIndicator />;
+          } else if (error || !data || !data.getChannelTotalProceeds) {
+            console.error("Error loading boost proceeds query:", error || "no data returned");
+            return (
+              <span style={{ color: "red" }}>
+                Error loading Boost proceed amounts: {JSON.stringify(error || "no data returned")}
+              </span>
+            );
+          }
+
+          let { totalAmount, ether, ethUsdAmount, usd } = data.getChannelTotalProceeds;
+          totalAmount = parseFloat(totalAmount || 0).toFixed(2);
+          ether = parseFloat(ether || 0).toFixed(5);
+          ethUsdAmount = parseFloat(ethUsdAmount || 0).toFixed(2);
+          usd = parseFloat(usd || 0).toFixed(2);
+
+          return (
+            <Wrapper>
+              <TotalProceeds>
+                <div>
+                  <TotalAmount>${totalAmount}</TotalAmount> <CurrencyLabel>USD</CurrencyLabel>
+                </div>
+                <div>Total Proceeds from Boosts</div>
+              </TotalProceeds>
+              <Proceed>
+                <div>
+                  <Amount>{ether}</Amount> <CurrencyLabel>ETH</CurrencyLabel> ~= ${ethUsdAmount}{" "}
+                  <CurrencyLabel>USD</CurrencyLabel>
+                </div>
+                <div>ETH Proceeds</div>
+              </Proceed>
+              <Proceed>
+                <div>
+                  <Amount>${usd}</Amount> <CurrencyLabel>USD</CurrencyLabel>
+                </div>
+                <div>Credit Card Proceeds</div>
+              </Proceed>
+            </Wrapper>
+          );
+        }}
+      </Query>
+    );
+  }
+}
+
+export const BoostProceeds: React.ComponentType<BoostProceedsProps> = withNewsroomChannel(
+  BoostProceedsComponent,
+) as any;

--- a/src/react/boosts/loader.tsx
+++ b/src/react/boosts/loader.tsx
@@ -11,6 +11,7 @@ import { Boost } from "./Boost";
 const apolloClient = getApolloClient();
 
 const { provider }: EthersProviderResult = makeEthersProvider("1");
+// @ts-ignore: @TODO this is failing with an error that we need to look into after web3 update
 const civil = new Civil({ web3Provider: provider });
 // @ts-ignore: Getting "Argument of type ... is not assignable to parameter of type ... Types have separate declarations of private property `ethApi`" because `buildCivilContext` is getting `Civil` from its copy of `@joincivil/core` and we're passing in from our copy. In practice, these `ethApi`s will be identical or matching interface.
 const civilContext = buildCivilContext(civil);

--- a/src/react/boosts/queries.ts
+++ b/src/react/boosts/queries.ts
@@ -71,6 +71,17 @@ export const boostNewsroomQuery = gql`
   }
 `;
 
+export const boostProceedsQuery = gql`
+  query proceeds($channelID: String!) {
+    getChannelTotalProceeds(channelID: $channelID) {
+      totalAmount
+      usd
+      ethUsdAmount
+      ether
+    }
+  }
+`;
+
 export const createBoostMutation = gql`
   mutation($input: PostCreateBoostInput!) {
     postsCreateBoost(input: $input) {


### PR DESCRIPTION
Together with https://github.com/joincivil/Civil/pull/1381 this adds the boost proceeds section (showing USD + ETH proceeds as well ability to withdraw ETH from withdraw) to the newsroom dashboard page. The designs for it are here: https://marvelapp.com/783djg9/screen/59420161/handoff